### PR TITLE
Change to use filesystem to convert to tiff image.

### DIFF
--- a/src/main/java/net/sourceforge/tess4j/util/ImageIOHelper.java
+++ b/src/main/java/net/sourceforge/tess4j/util/ImageIOHelper.java
@@ -274,6 +274,7 @@ public class ImageIOHelper {
         File temp = File.createTempFile("tess4j", ".tiff");
         ImageIO.write(image, "tiff", temp);
         BufferedImage bi = ImageIO.read(temp);
+        temp.delete();
         return convertImageData(bi);
     }
 

--- a/src/main/java/net/sourceforge/tess4j/util/ImageIOHelper.java
+++ b/src/main/java/net/sourceforge/tess4j/util/ImageIOHelper.java
@@ -271,31 +271,9 @@ public class ImageIOHelper {
      * @throws IOException
      */
     public static ByteBuffer getImageByteBuffer(RenderedImage image) throws IOException {
-        //Set up the writeParam
-        TIFFImageWriteParam tiffWriteParam = new TIFFImageWriteParam(Locale.US);
-        tiffWriteParam.setCompressionMode(ImageWriteParam.MODE_DISABLED);
-
-        //Get tif writer and set output to file
-        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName(TIFF_FORMAT);
-
-        if (!writers.hasNext()) {
-            throw new RuntimeException(JAI_IMAGE_WRITER_MESSAGE);
-        }
-
-        ImageWriter writer = writers.next();
-
-        //Get the stream metadata
-        IIOMetadata streamMetadata = writer.getDefaultStreamMetadata(tiffWriteParam);
-
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ImageOutputStream ios = ImageIO.createImageOutputStream(outputStream);
-        writer.setOutput(ios);
-        writer.write(streamMetadata, new IIOImage(image, null, null), tiffWriteParam);
-//        writer.write(image);
-        writer.dispose();
-//        ImageIO.write(image, "tiff", ios); // this can be used in lieu of writer
-        ios.seek(0);
-        BufferedImage bi = ImageIO.read(ios);
+        File temp = File.createTempFile("tess4j", ".tiff");
+        ImageIO.write(image, "tiff", temp);
+        BufferedImage bi = ImageIO.read(temp);
         return convertImageData(bi);
     }
 


### PR DESCRIPTION
Hi.

I know that this might not be the solution that you want to use to convert a tiff image.

The problem we are facing is that we work with our image and do some amount of image processing in java before the actual tess4j call and the tiff conversion almost crashes on line 297 when seeking the newly created buffer.

So this change fixed our stability remarkably so I wanted to open the discussion so we might find a solution that works reliably.

Best regards
Daniel

PS. Works even in multiple threaded runs DS.