### PR TITLE
Update PdfUtilities.java to resolve some multithread issues.

### DIFF
--- a/src/main/java/net/sourceforge/tess4j/util/PdfUtilities.java
+++ b/src/main/java/net/sourceforge/tess4j/util/PdfUtilities.java
@@ -56,10 +56,17 @@ public class PdfUtilities {
         } catch (NoClassDefFoundError ncdfe) {
             throw new RuntimeException(getMessage(ncdfe.getMessage()));
         } finally {
-            if (pngFiles != null) {
+            if (pngFiles != null && pngFiles.length>0) {
+	            //Get the working directory of the PNG files.
+                File pngDirectory = new File(pngFiles[0].getParent());
                 // delete temporary PNG images
                 for (File tempFile : pngFiles) {
                     tempFile.delete();
+                }
+                //Delete the working directory only if it was created with having same name as the pdf file.
+                if(pngDirectory.getAbsoluteFile().getName().equals(inputPdfFile.getName().replace(".pdf", "")))
+                {
+                    pngDirectory.delete();
                 }
             }
         }
@@ -71,8 +78,10 @@ public class PdfUtilities {
      * @param inputPdfFile input file
      * @return an array of PNG images
      */
-    public static File[] convertPdf2Png(File inputPdfFile) {
-        File imageDir = inputPdfFile.getParentFile();
+    @SuppressWarnings("unused")
+    public synchronized static File[] convertPdf2Png(File inputPdfFile) {
+        File imageDir = new File(inputPdfFile.getParentFile()+System.getProperty("file.separator")+inputPdfFile.getName().replace(".pdf", ""));
+        imageDir.mkdirs();
 
         if (imageDir == null) {
             String userDir = System.getProperty("user.dir");


### PR DESCRIPTION
1. Due to same working directory for the PNG files which follow fixed nomenclature, during multithreaded parallel requests for conversion of PDF files present in same directory, one that has just created PNG files, might be accessed by another thread at the time of reading from it (merging to its own tiff file) or for deleting it (for housekeeping). This can cause the extracted content to be inconsistent with the results in case of a single thread scenario. 

To resolve this, the update creates a unique working directory to hold the PNG files, and takes the same name as the PDF file, thereby separating the working directories of the parallel threads, and maintaining data consistency.

2. The original file only synchronized the gs object initialize and exit methods. When there are parallel threads, and one of them has completed the getInstance(), and then the synchronized initialize() and exit() methods, it will finally try to do Ghostscript.deleteInstance() outside the synchronized(gs) block. If there was a second thread that was given an instance by the getInstance() method, and was about to enter the synchronized(gs) block, and just before that an older first thread performed the Ghostscript.deleteInstance(), it would delete the gs instance for the second thread as well, causing an  exception. 

One solution that worked to resolve this issue was making the entire method synchronized. So that one thread does whatever it does with the gs object, and then cleanly deletes it without impacting another thread with possibly the same object.