### PR TITLE
 Added fix for incorrect path recognition when copying resources

### DIFF
--- a/src/main/java/net/sourceforge/tess4j/util/LoadLibs.java
+++ b/src/main/java/net/sourceforge/tess4j/util/LoadLibs.java
@@ -178,7 +178,7 @@ public class LoadLibs {
                 /**
                  * Extract files only if they match the path.
                  */
-                if (jarEntryName.startsWith(jarConnectionEntryName + "/")) {
+                if (jarEntryName.startsWith(jarConnectionEntryName + "/") || jarEntryName.startsWith(jarConnectionEntryName)) {
                     String filename = jarEntryName.substring(jarConnectionEntryName.length());
                     File targetFile = new File(destPath, filename);
 


### PR DESCRIPTION
When deploying under Tomcat 8.x on JRE 1.8 we have encoutered a bug where the `jarEntryName` field already contained the trailing slash. This has caused the automatic library loading to fail which in turn made the Tess4j unsuable.