### PR TITLE
Fix for BufferedImage OCR

### DIFF
--- a/src/test/java/net/sourceforge/tess4j/TesseractTest.java
+++ b/src/test/java/net/sourceforge/tess4j/TesseractTest.java
@@ -16,12 +16,15 @@
 package net.sourceforge.tess4j;
 
 import java.awt.Rectangle;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.Iterator;
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -177,9 +180,42 @@ public class TesseractTest {
         File imageFile = new File(this.testResourcesDataPath, "eurotext.png");
         BufferedImage bi = ImageIO.read(imageFile);
         String expResult = "The (quick) [brown] {fox} jumps!\nOver the $43,456.78 <lazy> #90 dog";
-        String result = instance.doOCR(bi);
-        logger.info(result);
-        assertEquals(expResult, result.substring(0, expResult.length()));
+
+        Map<String, Integer> types = new HashMap<>();
+        types.put("TYPE_INT_RGB", BufferedImage.TYPE_INT_RGB);
+        types.put("TYPE_INT_ARGB", BufferedImage.TYPE_INT_ARGB);
+        types.put("TYPE_INT_ARGB_PRE", BufferedImage.TYPE_INT_ARGB_PRE);
+        types.put("TYPE_INT_BGR", BufferedImage.TYPE_INT_BGR);
+        types.put("TYPE_3BYTE_BGR", BufferedImage.TYPE_3BYTE_BGR);
+        types.put("TYPE_4BYTE_ABGR", BufferedImage.TYPE_4BYTE_ABGR);
+        types.put("TYPE_4BYTE_ABGR_PRE", BufferedImage.TYPE_4BYTE_ABGR_PRE);
+        types.put("TYPE_USHORT_565_RGB", BufferedImage.TYPE_USHORT_565_RGB);
+        types.put("TYPE_USHORT_555_RGB", BufferedImage.TYPE_USHORT_555_RGB);
+        types.put("TYPE_BYTE_GRAY", BufferedImage.TYPE_BYTE_GRAY);
+        types.put("TYPE_USHORT_GRAY", BufferedImage.TYPE_USHORT_GRAY);
+        types.put("TYPE_BYTE_BINARY", BufferedImage.TYPE_BYTE_BINARY);
+        types.put("TYPE_BYTE_INDEXED", BufferedImage.TYPE_BYTE_INDEXED);
+
+        for (Map.Entry<String, Integer> entry: types.entrySet()) {
+            if (entry.getValue() == bi.getType()) {
+                String result = instance.doOCR(bi);
+                logger.info("BufferedImage type: " + entry.getKey() + " (Original)");
+                logger.info(result);
+                logger.info("");
+                assertEquals(expResult, result.substring(0, expResult.length()));
+            } else {
+                BufferedImage imageWithType = new BufferedImage(bi.getWidth(), bi.getHeight(), entry.getValue());
+                Graphics2D g = imageWithType.createGraphics();
+                g.drawImage(bi, 0, 0, null);
+                g.dispose();
+
+                String result = instance.doOCR(imageWithType);
+                logger.info("BufferedImage type: " + entry.getKey());
+                logger.info(result);
+                logger.info("");
+                assertEquals(expResult, result.substring(0, expResult.length()));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes #123 and modifies the relevant test cases.

From tess4j 4.2.0 onwards, BufferedImage with the type `TYPE_3BYTE_BGR` work correctly as usual but other types like `TYPE_INT_RGB` will only result in gibberish. Coincidentally `TYPE_INT_RGB` is the type that `Robot.createScreenCapture()` outputs (at least on my system), therefore the gibberish ocr. On the other hand `ImageIO.read(File file)` outputs `TYPE_3BYTE_BGR` image, which is why the ocr worked correctly and the original test case did not catch this bug. 

The only thing I find weird is that looking at the file blame, this function seems to be unchanged between pre-4.2.0 and post-4.2.0 so I think there must be something upstream in Tesseract 4.0.0-beta.4 that has affected the operation of tess4j in this regard.

In any case the returned `ByteBuffer` now contains the data in the right format regardless of what type the `BufferedImage` has. The only type case that the test case doesn't cover is the `TYPE_CUSTOM`