### PR TITLE
Restore Logback classic instead of core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <!-- Logging Dependencies -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
+            <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Classic is required to actually integrate as a backend for the tests.

 Fixes #202