### PR TITLE
Fix null pointer exceptions

### DIFF
--- a/src/main/java/net/sourceforge/tess4j/util/PdfBoxUtilities.java
+++ b/src/main/java/net/sourceforge/tess4j/util/PdfBoxUtilities.java
@@ -121,6 +121,14 @@ public class PdfBoxUtilities {
             }
         });
 
+        // workingFiles should be non-null here if the operation completed successfully
+        // https://docs.oracle.com/javase/7/docs/api/java/io/File.html#listFiles()
+        if (workingFiles == null) {
+            // Instead of throwing a NullPointerException, throw an IOException instead
+            // Clients of this library shouldn't be catching NullPointerExceptions thrown by this library
+            throw new IOException("Error extracting PDF Document");
+        }
+
         Arrays.sort(workingFiles, new Comparator<File>() {
             @Override
             public int compare(File f1, File f2) {

--- a/src/main/java/net/sourceforge/tess4j/util/PdfGsUtilities.java
+++ b/src/main/java/net/sourceforge/tess4j/util/PdfGsUtilities.java
@@ -136,6 +136,14 @@ public class PdfGsUtilities {
             }
         });
 
+        // workingFiles should be non-null here if the operation completed successfully
+        // https://docs.oracle.com/javase/7/docs/api/java/io/File.html#listFiles()
+        if (workingFiles == null) {
+            // Instead of throwing a NullPointerException, throw an IOException instead
+            // Clients of this library shouldn't be catching NullPointerExceptions thrown by this library
+            throw new IOException("Error extracting PDF Document");
+        }
+
         Arrays.sort(workingFiles, new Comparator<File>() {
             @Override
             public int compare(File f1, File f2) {


### PR DESCRIPTION
I use tess4j for PDF processing. I've noticed that if I provide a password-protected PDF file, that the convertPdf2Png method will just throw a NullPointerException.. This is very strange as the library should be throwing IOExceptions instead of NullPointerExceptions if it encounters any error during decoding.
