### PR TITLE
Remove API function TessBaseAPIInitLangMod

### DIFF
--- a/src/main/java/net/sourceforge/tess4j/TessAPI.java
+++ b/src/main/java/net/sourceforge/tess4j/TessAPI.java
@@ -363,25 +363,6 @@ public interface TessAPI extends Library, ITessAPI {
     PointerByReference TessBaseAPIGetAvailableLanguagesAsVector(TessBaseAPI handle);
 
     /**
-     * Init only the lang model component of Tesseract. The only functions that
-     * work after this init are <code>SetVariable</code> and
-     * <code>IsValidWord</code>. WARNING: temporary! This function will be
-     * removed from here and placed in a separate API at some future time.
-     *
-     * @param handle the TesseractAPI instance
-     * @param datapath The <code>datapath</code> must be the name of the parent
-     * directory of <code>tessdata</code> and must end in
-     * <i>/</i>. Any name after the last <i>/</i> will be stripped.
-     * @param language The language is (usually) an <code>ISO 639-3</code>
-     * string or <code>NULL</code> will default to eng. The language may be a
-     * string of the form [~]&lt;lang&gt;[+[~]&lt;lang&gt;] indicating that
-     * multiple languages are to be loaded. E.g., hin+eng will load Hindi and
-     * English.
-     * @return api init language mode
-     */
-    int TessBaseAPIInitLangMod(TessBaseAPI handle, String datapath, String language);
-
-    /**
      * Init only for page layout analysis. Use only for calls to
      * <code>SetImage</code> and <code>AnalysePage</code>. Calls that attempt
      * recognition will generate an error.

--- a/src/main/java/net/sourceforge/tess4j/TessAPI1.java
+++ b/src/main/java/net/sourceforge/tess4j/TessAPI1.java
@@ -363,25 +363,6 @@ public class TessAPI1 implements Library, ITessAPI {
     public static native PointerByReference TessBaseAPIGetAvailableLanguagesAsVector(TessBaseAPI handle);
 
     /**
-     * Init only the lang model component of Tesseract. The only functions that
-     * work after this init are <code>SetVariable</code> and
-     * <code>IsValidWord</code>. WARNING: temporary! This function will be
-     * removed from here and placed in a separate API at some future time.
-     *
-     * @param handle the TesseractAPI instance
-     * @param datapath The <code>datapath</code> must be the name of the parent
-     * directory of <code>tessdata</code> and must end in
-     * <i>/</i>. Any name after the last <i>/</i> will be stripped.
-     * @param language The language is (usually) an <code>ISO 639-3</code>
-     * string or <code>NULL</code> will default to eng. The language may be a
-     * string of the form [~]&lt;lang&gt;[+[~]&lt;lang&gt;] indicating that
-     * multiple languages are to be loaded. E.g., hin+eng will load Hindi and
-     * English.
-     * @return api init language mode
-     */
-    public static native int TessBaseAPIInitLangMod(TessBaseAPI handle, String datapath, String language);
-
-    /**
      * Init only for page layout analysis. Use only for calls to
      * <code>SetImage</code> and <code>AnalysePage</code>. Calls that attempt
      * recognition will generate an error.

--- a/src/test/java/net/sourceforge/tess4j/TessAPIImpl.java
+++ b/src/test/java/net/sourceforge/tess4j/TessAPIImpl.java
@@ -244,11 +244,6 @@ public class TessAPIImpl implements TessAPI {
     }
 
     @Override
-    public int TessBaseAPIInitLangMod(ITessAPI.TessBaseAPI handle, String datapath, String language) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
     public void TessBaseAPIInitForAnalysePage(ITessAPI.TessBaseAPI handle) {
         throw new UnsupportedOperationException("Not supported yet.");
     }


### PR DESCRIPTION
The function documentation included a warning that it would
be removed in the future. Tesseract 5.0.0 plans to remove it.

Signed-off-by: Stefan Weil <sw@weilnetz.de>