### PR TITLE
PR for issue 257: Tesseract1.doOCR method doesn't take into account the stride of the image

### DIFF
--- a/src/main/java/net/sourceforge/tess4j/Tesseract1.java
+++ b/src/main/java/net/sourceforge/tess4j/Tesseract1.java
@@ -547,7 +547,7 @@ public class Tesseract1 extends TessAPI1 implements ITesseract {
      */
     protected void setImage(int xsize, int ysize, ByteBuffer buf, int bpp) {
         int bytespp = bpp / 8;
-        int bytespl = (int) Math.ceil(xsize * bpp / 8.0);
+        int bytespl = buf.capacity() / ysize;
         TessBaseAPISetImage(handle, buf, xsize, ysize, bytespp, bytespl);
     }
 


### PR DESCRIPTION
https://github.com/nguyenq/tess4j/issues/257