### PR TITLE
Introduce Java Module System support and migrate to JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
+                    <release>11</release>
                     <debug>false</debug>
                 </configuration>
             </plugin>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright @ 2014 Quan Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+module net.sourceforge.tess4j {
+    requires com.sun.jna;
+    requires jai.imageio.core;
+    requires java.desktop;
+    requires java.xml;
+    requires jboss.vfs;
+    requires lept4j;
+    requires org.apache.commons.io;
+    requires org.apache.pdfbox;
+    requires org.apache.pdfbox.io;
+    requires org.apache.pdfbox.tools;
+    requires org.slf4j;
+
+    exports net.sourceforge.tess4j;
+    exports net.sourceforge.tess4j.util;
+    exports com.recognition.software.jdeskew;
+}


### PR DESCRIPTION
### Summary
This pull request modularizes the Tess4J project using the Java Module System and updates the Maven Compiler Plugin configuration to target JDK 11. The addition of the `module-info.java` file ensures better encapsulation and compatibility with modern Java versions.

### Changes
- Added `module-info.java` to define required modules and exported packages:
  - Specifies dependencies such as `org.apache.pdfbox`, `com.sun.jna`, and others.
  - Exports key packages like `net.sourceforge.tess4j`, `net.sourceforge.tess4j.util`, and `com.recognition.software.jdeskew`.
- Updated Maven Compiler Plugin configuration:
  - Changed `source`, `target`, and `release` from `1.8` to `11` for JDK 11 compatibility.

### Benefits
- Enables Tess4J to use the Java Module System for better encapsulation and maintainability.
- Aligns the project with modern Java standards and ensures future-proof compatibility.

### Impact
- Requires JDK 11 or higher to build and run the project.
- Downstream consumers using older JDK versions will need to upgrade.

### Testing
- Verified build and runtime compatibility with JDK 11.
- All unit tests pass successfully after the migration.

### Next Steps
- Review and merge to adopt JDK 11 and modularization fully.
- Update documentation and release notes to highlight JDK 11 as a new requirement.
